### PR TITLE
feat: implement functional terminal accessory bar for mobile

### DIFF
--- a/apps/web/src/components/TerminalAccessoryBar.tsx
+++ b/apps/web/src/components/TerminalAccessoryBar.tsx
@@ -1,13 +1,15 @@
 "use client";
 
+import { useCallback } from "react";
+
 interface TerminalAccessoryBarProps {
-  onKeyPress: (key: string) => void;
+  workspaceId: string;
   onMenuPress: () => void;
   disabled?: boolean;
 }
 
 export default function TerminalAccessoryBar({
-  onKeyPress,
+  workspaceId,
   onMenuPress,
   disabled = false,
 }: TerminalAccessoryBarProps) {
@@ -16,7 +18,20 @@ export default function TerminalAccessoryBar({
     { label: "TAB", value: "\t" },
     { label: "↑", value: "\x1b[A" },
     { label: "↓", value: "\x1b[B" },
+    { label: "←", value: "\x1b[D" },
+    { label: "→", value: "\x1b[C" },
   ];
+
+  // Dispatch custom event to send key to terminal
+  const sendKey = useCallback(
+    (key: string) => {
+      const event = new CustomEvent("terminal-input", {
+        detail: { workspaceId, key },
+      });
+      window.dispatchEvent(event);
+    },
+    [workspaceId]
+  );
 
   return (
     <div className="accessory-bar">
@@ -24,7 +39,7 @@ export default function TerminalAccessoryBar({
         <button
           key={key.label}
           className="accessory-btn"
-          onClick={() => onKeyPress(key.value)}
+          onClick={() => sendKey(key.value)}
           disabled={disabled}
           aria-label={key.label}
         >

--- a/apps/web/src/components/TerminalSection.tsx
+++ b/apps/web/src/components/TerminalSection.tsx
@@ -42,12 +42,6 @@ export default function TerminalSection({
     setIsFullscreen(!!document.fullscreenElement);
   }, []);
 
-  const handleKeyPress = useCallback((key: string) => {
-    // TODO: Implement key sending to terminal via a global event or context
-    // For now, accessory bar keys are visual-only on mobile
-    console.log("Accessory key pressed:", key);
-  }, []);
-
   const handleMenuPress = useCallback(() => {
     setShowMobileMenu(!showMobileMenu);
   }, [showMobileMenu]);
@@ -92,7 +86,7 @@ export default function TerminalSection({
 
       {/* Mobile Accessory Bar */}
       <TerminalAccessoryBar
-        onKeyPress={handleKeyPress}
+        workspaceId={workspaceId}
         onMenuPress={handleMenuPress}
         disabled={!isReady || !ipAddress}
       />


### PR DESCRIPTION
## Summary

- Add event listener in XTerminal to receive keystrokes from accessory bar
- Update TerminalAccessoryBar to dispatch custom events with workspace ID
- Add left/right arrow keys to accessory bar (now has ESC, TAB, ↑, ↓, ←, →)
- Remove unused handleKeyPress callback from TerminalSection

## How it works

The accessory bar now sends actual keystrokes to the terminal via custom DOM events:
1. User taps a key button on the accessory bar
2. `TerminalAccessoryBar` dispatches a `terminal-input` CustomEvent with `{workspaceId, key}`
3. `XTerminal` listens for these events and sends the keystroke via WebSocket using ttyd protocol

## Test plan

- [ ] Verify accessory bar buttons are visible on mobile viewport (375px)
- [ ] Verify buttons are disabled when workspace is offline
- [ ] Verify buttons send actual keystrokes when workspace is running
- [ ] Test ESC key cancels operations in terminal
- [ ] Test TAB key autocompletes in terminal
- [ ] Test arrow keys navigate command history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the mobile accessory bar functional by wiring its buttons to the terminal via a lightweight event bridge.
> 
> - `TerminalAccessoryBar`: replaces `onKeyPress` with `workspaceId` and dispatches `CustomEvent('terminal-input', {workspaceId, key})`; adds `←`/`→` keys
> - `XTerminal`: listens for `terminal-input` events (filtered by `workspaceId`) and forwards keys using ttyd protocol (`'0' + data`)
> - `TerminalSection`: passes `workspaceId` to `TerminalAccessoryBar` and removes unused `handleKeyPress` callback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f429dce0d9e685958b855d8378992f266d8b09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->