### PR TITLE
fix: terminal input and paste improvements

### DIFF
--- a/box/scripts/install-claude-cli.sh
+++ b/box/scripts/install-claude-cli.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "=== Installing Claude Code CLI ==="
+echo "=== Installing Claude Code CLI (Native) ==="
 
-# Install Claude Code CLI globally via npm
-echo "Installing Claude Code CLI via npm..."
-npm install -g @anthropic-ai/claude-code
+# Install Claude Code CLI using the official native installer
+# This is the recommended installation method - no Node.js dependency
+# https://code.claude.com/docs/en/setup
+echo "Installing Claude Code CLI via native installer..."
+
+# Run as coder user since the native installer installs to ~/.local/bin
+sudo -u coder bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
 
 # Verify installation
 echo "Verifying installation..."
-claude --version || echo "Claude CLI installed (version check may require API key)"
+sudo -u coder /home/coder/.local/bin/claude --version || echo "Claude CLI installed (version check may require API key)"
 
 # Create claude config directory for coder user
 mkdir -p /home/coder/.config/claude
@@ -27,7 +31,8 @@ chown coder:coder /home/coder/.config/claude/config.json
 # Add claude to coder's path profile
 cat >> /home/coder/.bashrc << 'BASHRC'
 
-# Claude Code CLI
+# Claude Code CLI (native installation)
+export PATH="$HOME/.local/bin:$PATH"
 export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
 
 # Alias for quick access
@@ -43,3 +48,4 @@ BASHRC
 
 echo "Claude Code CLI installation complete!"
 echo "Note: Users need to set ANTHROPIC_API_KEY environment variable"
+echo "Note: Claude binary installed to /home/coder/.local/bin/claude"


### PR DESCRIPTION
## Summary
- Add Ctrl+V paste support for Windows/Linux (Mac uses Cmd+V which works natively)
- Switch Claude Code installation from npm to native installer to fix input freeze bug

## Changes
1. **XTerminal.tsx**: Add custom key handler to intercept Ctrl+V and paste from clipboard
2. **install-claude-cli.sh**: Replace npm installation with official native installer

## Background
- Terminal input freezes after Claude Code starts ([known bug #8566](https://github.com/anthropics/claude-code/issues/8566))
- Ctrl+V doesn't work on Windows due to [xterm.js limitation](https://github.com/xtermjs/xterm.js/issues/2478)

## Test plan
- [ ] Create new workspace
- [ ] Verify Ctrl+V pastes on Windows
- [ ] Start Claude Code
- [ ] Verify terminal input works without needing Escape
- [ ] Verify paste still works inside Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves terminal paste handling and switches Claude CLI installation to the native method.
> 
> - `XTerminal.tsx`: Adds custom key handler to intercept `Ctrl+V` on Windows/Linux, pastes via `navigator.clipboard` by sending `"0" + text` over WebSocket; continues to block browser `Ctrl+W/T/N/L` so terminal apps receive them
> - `install-claude-cli.sh`: Replaces npm install with official native installer run as `coder`, updates PATH in `.bashrc`, verifies binary from `~/.local/bin`, and updates messages/config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7ed696dc486948452d4a80fe60771b97af810f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->