### PR TITLE
feat(web): custom auth pages using Clerk Elements

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,3 @@
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@ccc/api-contract": "workspace:*",
+    "@clerk/elements": "^0.24.2",
     "@clerk/nextjs": "^6.9.6",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider>
+    <ClerkProvider afterSignUpUrl="/dashboard/setup" afterSignInUrl="/dashboard">
       <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
         <body>{children}</body>
       </html>

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -22,7 +22,6 @@ export default function SignInPage() {
 
                 {/* Social Buttons */}
                 <div className="social-buttons">
-                  {/* TODO: Enable GitHub in Clerk Dashboard, then uncomment:
                   <Clerk.Connection name="github" className="social-btn">
                     <Clerk.Loading scope="provider:github">
                       {(isLoading) =>
@@ -30,14 +29,13 @@ export default function SignInPage() {
                           <span className="loading-spinner" />
                         ) : (
                           <>
-                            <_GitHubIcon />
+                            <GitHubIcon />
                             <span>GitHub</span>
                           </>
                         )
                       }
                     </Clerk.Loading>
                   </Clerk.Connection>
-                  */}
 
                   <Clerk.Connection name="google" className="social-btn">
                     <Clerk.Loading scope="provider:google">
@@ -510,8 +508,8 @@ export default function SignInPage() {
   );
 }
 
-// SVG Icons (GitHubIcon ready for when GitHub OAuth is enabled in Clerk Dashboard)
-function _GitHubIcon() {
+// SVG Icons
+function GitHubIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor">
       <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,16 +1,531 @@
-import { SignIn } from "@clerk/nextjs";
+"use client";
+
+import * as Clerk from "@clerk/elements/common";
+import * as SignIn from "@clerk/elements/sign-in";
 
 export default function SignInPage() {
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        minHeight: "100vh",
-      }}
-    >
-      <SignIn />
+    <div className="auth-container">
+      <SignIn.Root>
+        <Clerk.Loading>
+          {(isGlobalLoading) => (
+            <>
+              {/* Step 1: Start - Social + Email */}
+              <SignIn.Step name="start" className="auth-card">
+                <div className="auth-header">
+                  <span className="auth-label">AUTH.01 / SIGN_IN</span>
+                  <h1>Access Terminal</h1>
+                  <p>Sign in to your workspace</p>
+                </div>
+
+                <Clerk.GlobalError className="auth-global-error" />
+
+                {/* Social Buttons */}
+                <div className="social-buttons">
+                  {/* TODO: Enable GitHub in Clerk Dashboard, then uncomment:
+                  <Clerk.Connection name="github" className="social-btn">
+                    <Clerk.Loading scope="provider:github">
+                      {(isLoading) =>
+                        isLoading ? (
+                          <span className="loading-spinner" />
+                        ) : (
+                          <>
+                            <_GitHubIcon />
+                            <span>GitHub</span>
+                          </>
+                        )
+                      }
+                    </Clerk.Loading>
+                  </Clerk.Connection>
+                  */}
+
+                  <Clerk.Connection name="google" className="social-btn">
+                    <Clerk.Loading scope="provider:google">
+                      {(isLoading) =>
+                        isLoading ? (
+                          <span className="loading-spinner" />
+                        ) : (
+                          <>
+                            <GoogleIcon />
+                            <span>Google</span>
+                          </>
+                        )
+                      }
+                    </Clerk.Loading>
+                  </Clerk.Connection>
+                </div>
+
+                <div className="divider">
+                  <span>or continue with email</span>
+                </div>
+
+                {/* Email Input */}
+                <Clerk.Field name="identifier" className="auth-field">
+                  <Clerk.Label className="auth-label">Email Address</Clerk.Label>
+                  <Clerk.Input type="email" className="auth-input" placeholder="you@example.com" />
+                  <Clerk.FieldError className="auth-error" />
+                </Clerk.Field>
+
+                <SignIn.Action submit className="auth-submit" disabled={isGlobalLoading}>
+                  <Clerk.Loading>
+                    {(isLoading) => (isLoading ? <span className="loading-spinner" /> : "Continue")}
+                  </Clerk.Loading>
+                </SignIn.Action>
+
+                <div className="auth-footer">
+                  <span>New to the system?</span>
+                  <Clerk.Link navigate="sign-up" className="auth-link">
+                    Create account
+                  </Clerk.Link>
+                </div>
+              </SignIn.Step>
+
+              {/* Step 2: Verification - OTP Code */}
+              <SignIn.Step name="verifications" className="auth-card">
+                <SignIn.Strategy name="email_code">
+                  <div className="auth-header">
+                    <span className="auth-label">AUTH.02 / VERIFY</span>
+                    <h1>Check Your Email</h1>
+                    <p>
+                      We sent a code to <SignIn.SafeIdentifier />
+                    </p>
+                  </div>
+
+                  <Clerk.GlobalError className="auth-global-error" />
+
+                  <Clerk.Field name="code" className="auth-field">
+                    <Clerk.Label className="auth-label">Verification Code</Clerk.Label>
+                    <Clerk.Input
+                      type="otp"
+                      autoSubmit
+                      className="otp-input"
+                      render={({ value, status }) => (
+                        <span
+                          className={`otp-segment ${status === "cursor" ? "otp-cursor" : ""} ${status === "selected" ? "otp-selected" : ""}`}
+                          data-status={status}
+                        >
+                          {value || <span className="otp-placeholder">_</span>}
+                        </span>
+                      )}
+                    />
+                    <Clerk.FieldError className="auth-error" />
+                  </Clerk.Field>
+
+                  <SignIn.Action submit className="auth-submit" disabled={isGlobalLoading}>
+                    <Clerk.Loading>
+                      {(isLoading) => (isLoading ? <span className="loading-spinner" /> : "Verify")}
+                    </Clerk.Loading>
+                  </SignIn.Action>
+
+                  <div className="auth-actions">
+                    <SignIn.Action
+                      resend
+                      className="auth-link-btn"
+                      fallback={({ resendableAfter }) => (
+                        <span className="auth-muted">Resend in {resendableAfter}s</span>
+                      )}
+                    >
+                      Resend code
+                    </SignIn.Action>
+
+                    <SignIn.Action navigate="start" className="auth-link-btn">
+                      ← Back
+                    </SignIn.Action>
+                  </div>
+                </SignIn.Strategy>
+              </SignIn.Step>
+
+              {/* Step 3: Choose Strategy (fallback) */}
+              <SignIn.Step name="choose-strategy" className="auth-card">
+                <div className="auth-header">
+                  <span className="auth-label">AUTH.03 / OPTIONS</span>
+                  <h1>Alternative Methods</h1>
+                  <p>Choose another way to sign in</p>
+                </div>
+
+                <div className="strategy-options">
+                  <SignIn.SupportedStrategy name="email_code" asChild>
+                    <button className="strategy-btn">Email me a code</button>
+                  </SignIn.SupportedStrategy>
+                </div>
+
+                <SignIn.Action navigate="previous" className="auth-link-btn">
+                  ← Back
+                </SignIn.Action>
+              </SignIn.Step>
+            </>
+          )}
+        </Clerk.Loading>
+      </SignIn.Root>
+
+      <style jsx global>{`
+        .auth-container {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          min-height: 100vh;
+          padding: 1rem;
+          background: var(--background);
+        }
+
+        .auth-card {
+          width: 100%;
+          max-width: 400px;
+          background: var(--surface);
+          border: 1px solid var(--border);
+          padding: 2rem;
+        }
+
+        .auth-header {
+          text-align: center;
+          margin-bottom: 2rem;
+        }
+
+        .auth-header h1 {
+          font-size: 1.5rem;
+          font-weight: 700;
+          margin: 0.5rem 0;
+          color: var(--foreground);
+        }
+
+        .auth-header p {
+          color: var(--muted);
+          font-size: 0.875rem;
+        }
+
+        .auth-label {
+          font-family: var(--font-mono);
+          font-size: 0.625rem;
+          font-weight: 500;
+          text-transform: uppercase;
+          letter-spacing: 0.1em;
+          color: var(--muted);
+          display: block;
+          margin-bottom: 0.5rem;
+        }
+
+        /* Social Buttons */
+        .social-buttons {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          margin-bottom: 1.5rem;
+        }
+
+        .social-btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.75rem;
+          width: 100%;
+          padding: 0.875rem 1rem;
+          background: var(--surface);
+          color: var(--foreground);
+          border: 1px solid var(--border-strong);
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          font-weight: 500;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          cursor: pointer;
+          box-shadow: var(--shadow);
+          transition:
+            transform var(--transition-fast),
+            box-shadow var(--transition-fast),
+            background var(--transition);
+        }
+
+        .social-btn:hover {
+          background: var(--surface-hover);
+        }
+
+        .social-btn:active {
+          transform: translate(2px, 2px);
+          box-shadow: none;
+        }
+
+        .social-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .social-btn svg {
+          width: 18px;
+          height: 18px;
+        }
+
+        /* Divider */
+        .divider {
+          display: flex;
+          align-items: center;
+          gap: 1rem;
+          margin: 1.5rem 0;
+        }
+
+        .divider::before,
+        .divider::after {
+          content: "";
+          flex: 1;
+          height: 1px;
+          background: var(--border);
+        }
+
+        .divider span {
+          font-family: var(--font-mono);
+          font-size: 0.625rem;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--muted);
+        }
+
+        /* Form Fields */
+        .auth-field {
+          margin-bottom: 1.25rem;
+        }
+
+        .auth-input {
+          width: 100%;
+          padding: 0.875rem 1rem;
+          background: var(--background);
+          color: var(--foreground);
+          border: 1px solid var(--border);
+          font-family: var(--font-mono);
+          font-size: 0.875rem;
+          transition: border-color var(--transition);
+        }
+
+        .auth-input:focus {
+          outline: none;
+          border-color: var(--primary);
+        }
+
+        .auth-input::placeholder {
+          color: var(--muted);
+          opacity: 0.6;
+        }
+
+        .auth-input[data-invalid] {
+          border-color: var(--error);
+        }
+
+        .auth-error {
+          display: block;
+          margin-top: 0.5rem;
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--error);
+        }
+
+        .auth-global-error {
+          display: block;
+          padding: 0.75rem;
+          margin-bottom: 1rem;
+          background: rgba(255, 51, 51, 0.1);
+          border: 1px solid var(--error);
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--error);
+        }
+
+        /* Submit Button */
+        .auth-submit {
+          width: 100%;
+          padding: 1rem;
+          background: var(--primary);
+          color: white;
+          border: 1px solid var(--primary);
+          font-family: var(--font-mono);
+          font-size: 0.875rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          cursor: pointer;
+          box-shadow: var(--shadow);
+          transition:
+            transform var(--transition-fast),
+            box-shadow var(--transition-fast),
+            background var(--transition);
+        }
+
+        .auth-submit:hover {
+          background: var(--primary-hover);
+        }
+
+        .auth-submit:active {
+          transform: translate(2px, 2px);
+          box-shadow: none;
+        }
+
+        .auth-submit:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+          transform: none;
+          box-shadow: none;
+        }
+
+        /* OTP Input */
+        .otp-input {
+          display: flex;
+          justify-content: center;
+          gap: 0.5rem;
+        }
+
+        .otp-segment {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 48px;
+          height: 56px;
+          background: var(--background);
+          border: 1px solid var(--border);
+          font-family: var(--font-mono);
+          font-size: 1.5rem;
+          font-weight: 600;
+          color: var(--foreground);
+          transition: border-color var(--transition);
+        }
+
+        .otp-segment.otp-cursor {
+          border-color: var(--primary);
+        }
+
+        .otp-segment.otp-selected {
+          border-color: var(--selection);
+          background: rgba(0, 85, 255, 0.1);
+        }
+
+        .otp-placeholder {
+          color: var(--muted);
+          opacity: 0.3;
+        }
+
+        @media (max-width: 400px) {
+          .otp-segment {
+            width: 40px;
+            height: 48px;
+            font-size: 1.25rem;
+          }
+        }
+
+        /* Footer & Links */
+        .auth-footer {
+          display: flex;
+          justify-content: center;
+          gap: 0.5rem;
+          margin-top: 1.5rem;
+          font-size: 0.875rem;
+          color: var(--muted);
+        }
+
+        .auth-link {
+          color: var(--primary);
+          font-weight: 500;
+          cursor: pointer;
+          transition: color var(--transition);
+        }
+
+        .auth-link:hover {
+          color: var(--primary-hover);
+        }
+
+        .auth-actions {
+          display: flex;
+          justify-content: space-between;
+          margin-top: 1.5rem;
+        }
+
+        .auth-link-btn {
+          background: none;
+          border: none;
+          padding: 0.5rem;
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--muted);
+          cursor: pointer;
+          transition: color var(--transition);
+        }
+
+        .auth-link-btn:hover {
+          color: var(--foreground);
+        }
+
+        .auth-muted {
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--muted);
+        }
+
+        /* Strategy Options */
+        .strategy-options {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          margin-bottom: 1.5rem;
+        }
+
+        .strategy-btn {
+          width: 100%;
+          padding: 0.875rem 1rem;
+          background: var(--surface);
+          color: var(--foreground);
+          border: 1px solid var(--border-strong);
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          cursor: pointer;
+          box-shadow: var(--shadow);
+          transition:
+            transform var(--transition-fast),
+            box-shadow var(--transition-fast);
+        }
+
+        .strategy-btn:hover {
+          background: var(--surface-hover);
+        }
+
+        .strategy-btn:active {
+          transform: translate(2px, 2px);
+          box-shadow: none;
+        }
+
+        /* Loading Spinner */
+        .loading-spinner {
+          display: inline-block;
+          width: 16px;
+          height: 16px;
+          border: 2px solid currentColor;
+          border-right-color: transparent;
+          border-radius: 50%;
+          animation: spin 0.6s linear infinite;
+        }
+
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
     </div>
+  );
+}
+
+// SVG Icons (GitHubIcon ready for when GitHub OAuth is enabled in Clerk Dashboard)
+function _GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+    </svg>
   );
 }

--- a/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -22,7 +22,6 @@ export default function SignUpPage() {
 
                 {/* Social Buttons */}
                 <div className="social-buttons">
-                  {/* TODO: Enable GitHub in Clerk Dashboard, then uncomment:
                   <Clerk.Connection name="github" className="social-btn">
                     <Clerk.Loading scope="provider:github">
                       {(isLoading) =>
@@ -30,14 +29,13 @@ export default function SignUpPage() {
                           <span className="loading-spinner" />
                         ) : (
                           <>
-                            <_GitHubIcon />
+                            <GitHubIcon />
                             <span>GitHub</span>
                           </>
                         )
                       }
                     </Clerk.Loading>
                   </Clerk.Connection>
-                  */}
 
                   <Clerk.Connection name="google" className="social-btn">
                     <Clerk.Loading scope="provider:google">
@@ -487,8 +485,8 @@ export default function SignUpPage() {
   );
 }
 
-// SVG Icons (GitHubIcon ready for when GitHub OAuth is enabled in Clerk Dashboard)
-function _GitHubIcon() {
+// SVG Icons
+function GitHubIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor">
       <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />

--- a/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,16 +1,508 @@
-import { SignUp } from "@clerk/nextjs";
+"use client";
+
+import * as Clerk from "@clerk/elements/common";
+import * as SignUp from "@clerk/elements/sign-up";
 
 export default function SignUpPage() {
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        minHeight: "100vh",
-      }}
-    >
-      <SignUp afterSignUpUrl="/dashboard/setup" afterSignInUrl="/dashboard" />
+    <div className="auth-container">
+      <SignUp.Root>
+        <Clerk.Loading>
+          {(isGlobalLoading) => (
+            <>
+              {/* Step 1: Start - Social + Email */}
+              <SignUp.Step name="start" className="auth-card">
+                <div className="auth-header">
+                  <span className="auth-label">REG.01 / CREATE_ACCOUNT</span>
+                  <h1>Initialize System</h1>
+                  <p>Create your workspace account</p>
+                </div>
+
+                <Clerk.GlobalError className="auth-global-error" />
+
+                {/* Social Buttons */}
+                <div className="social-buttons">
+                  {/* TODO: Enable GitHub in Clerk Dashboard, then uncomment:
+                  <Clerk.Connection name="github" className="social-btn">
+                    <Clerk.Loading scope="provider:github">
+                      {(isLoading) =>
+                        isLoading ? (
+                          <span className="loading-spinner" />
+                        ) : (
+                          <>
+                            <_GitHubIcon />
+                            <span>GitHub</span>
+                          </>
+                        )
+                      }
+                    </Clerk.Loading>
+                  </Clerk.Connection>
+                  */}
+
+                  <Clerk.Connection name="google" className="social-btn">
+                    <Clerk.Loading scope="provider:google">
+                      {(isLoading) =>
+                        isLoading ? (
+                          <span className="loading-spinner" />
+                        ) : (
+                          <>
+                            <GoogleIcon />
+                            <span>Google</span>
+                          </>
+                        )
+                      }
+                    </Clerk.Loading>
+                  </Clerk.Connection>
+                </div>
+
+                <div className="divider">
+                  <span>or continue with email</span>
+                </div>
+
+                {/* Email Input */}
+                <Clerk.Field name="emailAddress" className="auth-field">
+                  <Clerk.Label className="auth-label">Email Address</Clerk.Label>
+                  <Clerk.Input type="email" className="auth-input" placeholder="you@example.com" />
+                  <Clerk.FieldError className="auth-error" />
+                </Clerk.Field>
+
+                <SignUp.Captcha className="captcha-container" />
+
+                <SignUp.Action submit className="auth-submit" disabled={isGlobalLoading}>
+                  <Clerk.Loading>
+                    {(isLoading) =>
+                      isLoading ? <span className="loading-spinner" /> : "Create Account"
+                    }
+                  </Clerk.Loading>
+                </SignUp.Action>
+
+                <div className="auth-footer">
+                  <span>Already have access?</span>
+                  <Clerk.Link navigate="sign-in" className="auth-link">
+                    Sign in
+                  </Clerk.Link>
+                </div>
+              </SignUp.Step>
+
+              {/* Step 2: Continue - Extra fields if needed (e.g., after OAuth) */}
+              <SignUp.Step name="continue" className="auth-card">
+                <div className="auth-header">
+                  <span className="auth-label">REG.02 / COMPLETE_PROFILE</span>
+                  <h1>Almost There</h1>
+                  <p>Complete your account setup</p>
+                </div>
+
+                <Clerk.GlobalError className="auth-global-error" />
+
+                <Clerk.Field name="emailAddress" className="auth-field">
+                  <Clerk.Label className="auth-label">Email Address</Clerk.Label>
+                  <Clerk.Input type="email" className="auth-input" placeholder="you@example.com" />
+                  <Clerk.FieldError className="auth-error" />
+                </Clerk.Field>
+
+                <SignUp.Action submit className="auth-submit" disabled={isGlobalLoading}>
+                  <Clerk.Loading>
+                    {(isLoading) => (isLoading ? <span className="loading-spinner" /> : "Continue")}
+                  </Clerk.Loading>
+                </SignUp.Action>
+              </SignUp.Step>
+
+              {/* Step 3: Verification - OTP Code */}
+              <SignUp.Step name="verifications" className="auth-card">
+                <SignUp.Strategy name="email_code">
+                  <div className="auth-header">
+                    <span className="auth-label">REG.03 / VERIFY</span>
+                    <h1>Verify Email</h1>
+                    <p>Enter the code sent to your email</p>
+                  </div>
+
+                  <Clerk.GlobalError className="auth-global-error" />
+
+                  <Clerk.Field name="code" className="auth-field">
+                    <Clerk.Label className="auth-label">Verification Code</Clerk.Label>
+                    <Clerk.Input
+                      type="otp"
+                      autoSubmit
+                      className="otp-input"
+                      render={({ value, status }) => (
+                        <span
+                          className={`otp-segment ${status === "cursor" ? "otp-cursor" : ""} ${status === "selected" ? "otp-selected" : ""}`}
+                          data-status={status}
+                        >
+                          {value || <span className="otp-placeholder">_</span>}
+                        </span>
+                      )}
+                    />
+                    <Clerk.FieldError className="auth-error" />
+                  </Clerk.Field>
+
+                  <SignUp.Action submit className="auth-submit" disabled={isGlobalLoading}>
+                    <Clerk.Loading>
+                      {(isLoading) => (isLoading ? <span className="loading-spinner" /> : "Verify")}
+                    </Clerk.Loading>
+                  </SignUp.Action>
+
+                  <div className="auth-actions">
+                    <SignUp.Action
+                      resend
+                      className="auth-link-btn"
+                      fallback={({ resendableAfter }) => (
+                        <span className="auth-muted">Resend in {resendableAfter}s</span>
+                      )}
+                    >
+                      Resend code
+                    </SignUp.Action>
+
+                    <SignUp.Action navigate="start" className="auth-link-btn">
+                      ← Back
+                    </SignUp.Action>
+                  </div>
+                </SignUp.Strategy>
+              </SignUp.Step>
+            </>
+          )}
+        </Clerk.Loading>
+      </SignUp.Root>
+
+      <style jsx global>{`
+        .auth-container {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          min-height: 100vh;
+          padding: 1rem;
+          background: var(--background);
+        }
+
+        .auth-card {
+          width: 100%;
+          max-width: 400px;
+          background: var(--surface);
+          border: 1px solid var(--border);
+          padding: 2rem;
+        }
+
+        .auth-header {
+          text-align: center;
+          margin-bottom: 2rem;
+        }
+
+        .auth-header h1 {
+          font-size: 1.5rem;
+          font-weight: 700;
+          margin: 0.5rem 0;
+          color: var(--foreground);
+        }
+
+        .auth-header p {
+          color: var(--muted);
+          font-size: 0.875rem;
+        }
+
+        .auth-label {
+          font-family: var(--font-mono);
+          font-size: 0.625rem;
+          font-weight: 500;
+          text-transform: uppercase;
+          letter-spacing: 0.1em;
+          color: var(--muted);
+          display: block;
+          margin-bottom: 0.5rem;
+        }
+
+        /* Social Buttons */
+        .social-buttons {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          margin-bottom: 1.5rem;
+        }
+
+        .social-btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.75rem;
+          width: 100%;
+          padding: 0.875rem 1rem;
+          background: var(--surface);
+          color: var(--foreground);
+          border: 1px solid var(--border-strong);
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          font-weight: 500;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          cursor: pointer;
+          box-shadow: var(--shadow);
+          transition:
+            transform var(--transition-fast),
+            box-shadow var(--transition-fast),
+            background var(--transition);
+        }
+
+        .social-btn:hover {
+          background: var(--surface-hover);
+        }
+
+        .social-btn:active {
+          transform: translate(2px, 2px);
+          box-shadow: none;
+        }
+
+        .social-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .social-btn svg {
+          width: 18px;
+          height: 18px;
+        }
+
+        /* Divider */
+        .divider {
+          display: flex;
+          align-items: center;
+          gap: 1rem;
+          margin: 1.5rem 0;
+        }
+
+        .divider::before,
+        .divider::after {
+          content: "";
+          flex: 1;
+          height: 1px;
+          background: var(--border);
+        }
+
+        .divider span {
+          font-family: var(--font-mono);
+          font-size: 0.625rem;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--muted);
+        }
+
+        /* Form Fields */
+        .auth-field {
+          margin-bottom: 1.25rem;
+        }
+
+        .auth-input {
+          width: 100%;
+          padding: 0.875rem 1rem;
+          background: var(--background);
+          color: var(--foreground);
+          border: 1px solid var(--border);
+          font-family: var(--font-mono);
+          font-size: 0.875rem;
+          transition: border-color var(--transition);
+        }
+
+        .auth-input:focus {
+          outline: none;
+          border-color: var(--primary);
+        }
+
+        .auth-input::placeholder {
+          color: var(--muted);
+          opacity: 0.6;
+        }
+
+        .auth-input[data-invalid] {
+          border-color: var(--error);
+        }
+
+        .auth-error {
+          display: block;
+          margin-top: 0.5rem;
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--error);
+        }
+
+        .auth-global-error {
+          display: block;
+          padding: 0.75rem;
+          margin-bottom: 1rem;
+          background: rgba(255, 51, 51, 0.1);
+          border: 1px solid var(--error);
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--error);
+        }
+
+        /* Captcha Container */
+        .captcha-container {
+          margin-bottom: 1.25rem;
+        }
+
+        /* Submit Button */
+        .auth-submit {
+          width: 100%;
+          padding: 1rem;
+          background: var(--primary);
+          color: white;
+          border: 1px solid var(--primary);
+          font-family: var(--font-mono);
+          font-size: 0.875rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          cursor: pointer;
+          box-shadow: var(--shadow);
+          transition:
+            transform var(--transition-fast),
+            box-shadow var(--transition-fast),
+            background var(--transition);
+        }
+
+        .auth-submit:hover {
+          background: var(--primary-hover);
+        }
+
+        .auth-submit:active {
+          transform: translate(2px, 2px);
+          box-shadow: none;
+        }
+
+        .auth-submit:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+          transform: none;
+          box-shadow: none;
+        }
+
+        /* OTP Input */
+        .otp-input {
+          display: flex;
+          justify-content: center;
+          gap: 0.5rem;
+        }
+
+        .otp-segment {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 48px;
+          height: 56px;
+          background: var(--background);
+          border: 1px solid var(--border);
+          font-family: var(--font-mono);
+          font-size: 1.5rem;
+          font-weight: 600;
+          color: var(--foreground);
+          transition: border-color var(--transition);
+        }
+
+        .otp-segment.otp-cursor {
+          border-color: var(--primary);
+        }
+
+        .otp-segment.otp-selected {
+          border-color: var(--selection);
+          background: rgba(0, 85, 255, 0.1);
+        }
+
+        .otp-placeholder {
+          color: var(--muted);
+          opacity: 0.3;
+        }
+
+        @media (max-width: 400px) {
+          .otp-segment {
+            width: 40px;
+            height: 48px;
+            font-size: 1.25rem;
+          }
+        }
+
+        /* Footer & Links */
+        .auth-footer {
+          display: flex;
+          justify-content: center;
+          gap: 0.5rem;
+          margin-top: 1.5rem;
+          font-size: 0.875rem;
+          color: var(--muted);
+        }
+
+        .auth-link {
+          color: var(--primary);
+          font-weight: 500;
+          cursor: pointer;
+          transition: color var(--transition);
+        }
+
+        .auth-link:hover {
+          color: var(--primary-hover);
+        }
+
+        .auth-actions {
+          display: flex;
+          justify-content: space-between;
+          margin-top: 1.5rem;
+        }
+
+        .auth-link-btn {
+          background: none;
+          border: none;
+          padding: 0.5rem;
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--muted);
+          cursor: pointer;
+          transition: color var(--transition);
+        }
+
+        .auth-link-btn:hover {
+          color: var(--foreground);
+        }
+
+        .auth-muted {
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          color: var(--muted);
+        }
+
+        /* Loading Spinner */
+        .loading-spinner {
+          display: inline-block;
+          width: 16px;
+          height: 16px;
+          border: 2px solid currentColor;
+          border-right-color: transparent;
+          border-radius: 50%;
+          animation: spin 0.6s linear infinite;
+        }
+
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
     </div>
+  );
+}
+
+// SVG Icons (GitHubIcon ready for when GitHub OAuth is enabled in Clerk Dashboard)
+function _GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+    </svg>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       "@ccc/api-contract":
         specifier: workspace:*
         version: link:../../packages/api-contract
+      "@clerk/elements":
+        specifier: ^0.24.2
+        version: 0.24.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       "@clerk/nextjs":
         specifier: ^6.9.6
         version: 6.36.5(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -215,6 +218,20 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  "@clerk/elements@0.24.2":
+    resolution:
+      {
+        integrity: sha512-/SZNRftg/ZArTJtKdhoPHCfQZJ6w1Sd661e57Pl2FATniOh74oFEWFoVTQbDKvNtdwSGodIjJizOLAnWJvdhaQ==,
+      }
+    engines: { node: ">=18.17.0" }
+    peerDependencies:
+      next: ^13.5.7 || ^14.2.25 || ^15.2.3 || ^16
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   "@clerk/nextjs@6.36.5":
     resolution:
@@ -1531,6 +1548,132 @@ packages:
         integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==,
       }
 
+  "@radix-ui/primitive@1.1.3":
+    resolution:
+      {
+        integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==,
+      }
+
+  "@radix-ui/react-compose-refs@1.1.2":
+    resolution:
+      {
+        integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-context@1.1.2":
+    resolution:
+      {
+        integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-form@0.1.8":
+    resolution:
+      {
+        integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-id@1.1.1":
+    resolution:
+      {
+        integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-label@2.1.7":
+    resolution:
+      {
+        integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-primitive@2.1.3":
+    resolution:
+      {
+        integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-slot@1.2.3":
+    resolution:
+      {
+        integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-slot@1.2.4":
+    resolution:
+      {
+        integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-layout-effect@1.1.1":
+    resolution:
+      {
+        integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@rollup/rollup-android-arm-eabi@4.54.0":
     resolution:
       {
@@ -1919,6 +2062,18 @@ packages:
       {
         integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
       }
+
+  "@xstate/react@6.0.0":
+    resolution:
+      {
+        integrity: sha512-xXlLpFJxqLhhmecAXclBECgk+B4zYSrDTl8hTfPZBogkn82OHKbm9zJxox3Z/YXoOhAQhKFTRLMYGdlbhc6T9A==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      xstate: ^5.20.0
+    peerDependenciesMeta:
+      xstate:
+        optional: true
 
   "@xterm/addon-canvas@0.7.0":
     resolution:
@@ -4346,6 +4501,13 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
+  type-fest@4.41.0:
+    resolution:
+      {
+        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
+      }
+    engines: { node: ">=16" }
+
   typed-array-buffer@1.0.3:
     resolution:
       {
@@ -4400,6 +4562,18 @@ packages:
       {
         integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
       }
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution:
+      {
+        integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution:
@@ -4560,6 +4734,12 @@ packages:
       utf-8-validate:
         optional: true
 
+  xstate@5.25.0:
+    resolution:
+      {
+        integrity: sha512-yyWzfhVRoTHNLjLoMmdwZGagAYfmnzpm9gPjlX2MhJZsDojXGqRxODDOi4BsgGRKD46NZRAdcLp6CKOyvQS0Bw==,
+      }
+
   xterm-local-echo@1.0.0:
     resolution:
       {
@@ -4605,6 +4785,27 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       tslib: 2.8.1
+
+  "@clerk/elements@0.24.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+    dependencies:
+      "@clerk/clerk-react": 5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      "@clerk/shared": 3.41.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      "@clerk/types": 4.101.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-form": 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      "@radix-ui/react-slot": 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      "@xstate/react": 6.0.0(@types/react@19.2.7)(react@19.2.3)(xstate@5.25.0)
+      client-only: 0.0.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+      type-fest: 4.41.0
+      xstate: 5.25.0
+    optionalDependencies:
+      next: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - "@types/react"
+      - "@types/react-dom"
 
   "@clerk/nextjs@6.36.5(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
     dependencies:
@@ -5128,6 +5329,79 @@ snapshots:
 
   "@petamoriken/float16@3.9.3": {}
 
+  "@radix-ui/primitive@1.1.3": {}
+
+  "@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.7)(react@19.2.3)":
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-context@1.1.2(@types/react@19.2.7)(react@19.2.3)":
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.3
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      "@radix-ui/react-context": 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      "@radix-ui/react-id": 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      "@radix-ui/react-label": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-id@1.1.1(@types/react@19.2.7)(react@19.2.3)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+    dependencies:
+      "@radix-ui/react-slot": 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-slot@1.2.3(@types/react@19.2.7)(react@19.2.3)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-slot@1.2.4(@types/react@19.2.7)(react@19.2.3)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.7)(react@19.2.3)":
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@rollup/rollup-android-arm-eabi@4.54.0":
     optional: true
 
@@ -5366,6 +5640,16 @@ snapshots:
       "@vitest/pretty-format": 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  "@xstate/react@6.0.0(@types/react@19.2.7)(react@19.2.3)(xstate@5.25.0)":
+    dependencies:
+      react: 19.2.3
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.7)(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      xstate: 5.25.0
+    transitivePeerDependencies:
+      - "@types/react"
 
   "@xterm/addon-canvas@0.7.0(@xterm/xterm@5.5.0)":
     dependencies:
@@ -6928,6 +7212,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -6975,6 +7261,12 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      "@types/react": 19.2.7
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
@@ -7105,6 +7397,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   ws@8.18.3: {}
+
+  xstate@5.25.0: {}
 
   xterm-local-echo@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Replace pre-built Clerk `<SignIn />` and `<SignUp />` components with custom UI using `@clerk/elements`
- Add multi-step auth flows: start → verification → (choose-strategy for sign-in)
- Implement OTP input with auto-submit, resend cooldown, and segmented display
- Add loading states to all buttons and OAuth connections
- Style with styled-jsx matching app design system (dark theme, orange accent, monospace)

## Changes

- **New dependency:** `@clerk/elements ^0.24.2`
- **Sign-In page:** Social (Google) + email entry → OTP verification → alternative strategies
- **Sign-Up page:** Social (Google) + email entry → continue (extra fields) → OTP verification

## UX Improvements

- Full-width touch targets on mobile (tested at 375px)
- OAuth uses redirect mode (no narrow popups)
- Numeric keypad for OTP via `type="otp"`
- Immediate visual feedback on all actions

## TODO (requires Clerk Dashboard config)

- [ ] Enable GitHub OAuth in Clerk Dashboard
- [ ] Uncomment GitHub button code in both pages

## Test plan

- [x] TypeScript compiles without errors
- [x] Visual testing with dev-browser (desktop 1280px, mobile 375px)
- [x] Google OAuth flow renders correctly
- [x] Email input shows keyboard on mobile
- [ ] Manual test: complete sign-in flow with email OTP
- [ ] Manual test: complete sign-up flow with email OTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces fully custom auth UIs built with `@clerk/elements`, replacing prebuilt components and adding multi-step flows.
> 
> - Rewrites `sign-in` and `sign-up` pages to use `SignIn.Root`/`SignUp.Root` with steps: `start` (social GitHub/Google + email), OTP `verifications` (auto-submit, segmented display, resend), plus `choose-strategy` (sign-in) and `continue` (sign-up); includes loading states and styled-jsx UI
> - Adds `@clerk/elements` dependency; updates `ClerkProvider` with `afterSignUpUrl="/dashboard/setup"` and `afterSignInUrl="/dashboard"`
> - Adds `apps/web/.gitignore` to ignore `/.clerk/` configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4368f28b19f11a6585f693ef1ec92cae36d29bb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->