### PR TITLE
fix: replace deprecated Clerk redirect props

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -36,7 +36,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider afterSignUpUrl="/dashboard/setup" afterSignInUrl="/dashboard">
+    <ClerkProvider
+      signUpFallbackRedirectUrl="/dashboard/setup"
+      signInFallbackRedirectUrl="/dashboard"
+    >
       <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
         <body>{children}</body>
       </html>


### PR DESCRIPTION
## Summary
Fixes the GitHub OAuth redirect loop after login by replacing deprecated Clerk props.

## Changes
- Replace `afterSignUpUrl` with `signUpFallbackRedirectUrl`
- Replace `afterSignInUrl` with `signInFallbackRedirectUrl`

## Issue
After logging in with GitHub, users were redirected back to the login page. Console showed:
> Clerk: The prop "afterSignUpUrl" is deprecated and should be replaced with the new "fallbackRedirectUrl" or "forceRedirectUrl" props instead.

## Testing
- [ ] Login with GitHub OAuth
- [ ] Verify redirect to `/dashboard` after sign-in
- [ ] Verify redirect to `/dashboard/setup` after sign-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `ClerkProvider` in `apps/web/src/app/layout.tsx` to use new redirect props for auth flows.
> 
> - Replace deprecated `afterSignUpUrl` with `signUpFallbackRedirectUrl`
> - Replace deprecated `afterSignInUrl` with `signInFallbackRedirectUrl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd67e2cb2d1f5ec76157b28fac6116bc0ebd16ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->