### PR TITLE
fix: use neutral message for workspace startup

### DIFF
--- a/apps/web/src/components/BootLog.tsx
+++ b/apps/web/src/components/BootLog.tsx
@@ -112,7 +112,7 @@ export default function BootLog({
         if (isAlreadyStarting && !canStart) {
           if (!isMounted.current) return; // Don't start polling if unmounted
           setPhase("provisioning");
-          addLog("Resuming workspace startup...");
+          addLog("Workspace starting...");
           setProgress(30);
           startPolling(token);
           return;


### PR DESCRIPTION
## Summary
- Changes "Resuming workspace startup..." to "Workspace starting..." in BootLog.tsx

## Problem
When a user creates a **brand new** workspace, the boot log showed "Resuming workspace startup..." which was confusing because:
- "Resuming" implies there was a previous session that was interrupted
- New users see this on their FIRST workspace, which makes no sense

## Solution
Changed the message to neutral phrasing that works for both:
- New workspace: "Workspace starting..." ✓
- Resume: "Workspace starting..." ✓ (still true, picking up where provisioning is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts boot log copy for clarity during workspace startup.
> 
> - Updates `BootLog.tsx` to log "Workspace starting..." instead of "Resuming workspace startup..." when `isAlreadyStarting && !canStart`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ecdca5ff37c782543e21bfa89718454139b6b94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->