### PR TITLE
Release: Boot log message fix

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -36,7 +36,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider afterSignUpUrl="/dashboard/setup" afterSignInUrl="/dashboard">
+    <ClerkProvider
+      signUpFallbackRedirectUrl="/dashboard/setup"
+      signInFallbackRedirectUrl="/dashboard"
+    >
       <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
         <body>{children}</body>
       </html>

--- a/apps/web/src/components/BootLog.tsx
+++ b/apps/web/src/components/BootLog.tsx
@@ -112,7 +112,7 @@ export default function BootLog({
         if (isAlreadyStarting && !canStart) {
           if (!isMounted.current) return; // Don't start polling if unmounted
           setPhase("provisioning");
-          addLog("Resuming workspace startup...");
+          addLog("Workspace starting...");
           setProgress(30);
           startPolling(token);
           return;


### PR DESCRIPTION
## Summary
- Fix confusing "Resuming workspace startup..." message for new workspaces

## Changes
- `apps/web/src/components/BootLog.tsx`: Changed message from "Resuming workspace startup..." to "Workspace starting..."

## Why
New users saw "Resuming" on their first workspace creation, which was confusing since there was nothing to resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Auth redirect props:** Replace `afterSignUpUrl`/`afterSignInUrl` with `signUpFallbackRedirectUrl`/`signInFallbackRedirectUrl` in `apps/web/src/app/layout.tsx`.
> - **Boot log copy:** Update message in `apps/web/src/components/BootLog.tsx` when resuming/polling to `"Workspace starting..."`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe328e37362b6952c4bb1cadc988c8179d1c45e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->