### PR TITLE
fix: improve waitlist form contrast

### DIFF
--- a/apps/web/src/app/waitlist/page.tsx
+++ b/apps/web/src/app/waitlist/page.tsx
@@ -81,12 +81,26 @@ export default function WaitlistPage() {
           display: none !important;
         }
 
+        .cl-formFieldLabel {
+          color: var(--foreground) !important;
+          font-family: var(--font-mono) !important;
+          font-size: 0.75rem !important;
+          font-weight: 500 !important;
+          text-transform: uppercase !important;
+          letter-spacing: 0.05em !important;
+        }
+
         .cl-formFieldInput {
           background: var(--background) !important;
           border: 1px solid var(--border) !important;
           border-radius: 0 !important;
           color: var(--foreground) !important;
           font-family: var(--font-mono) !important;
+        }
+
+        .cl-formFieldInput::placeholder {
+          color: var(--muted) !important;
+          opacity: 0.7 !important;
         }
 
         .cl-formFieldInput:focus {


### PR DESCRIPTION
Fix low contrast for email label and placeholder text on waitlist page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances readability and contrast on the waitlist form.
> 
> - Adds styling for `cl-formFieldLabel` (foreground color, mono font, size/weight, uppercase, letter-spacing)
> - Tweaks `cl-formFieldInput::placeholder` (muted color with increased opacity) for clearer placeholder text
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53353817d56967a1973f533635879108179480e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->