### PR TITLE
feat: add orange terminal cursor to auth inputs

### DIFF
--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -306,6 +306,7 @@ export default function SignInPage() {
           font-family: var(--font-mono);
           font-size: 0.875rem;
           transition: border-color var(--transition);
+          caret-color: var(--primary);
         }
 
         .auth-input:focus {

--- a/apps/web/src/app/sign-up/[[...sign-up]]/SignUpForm.tsx
+++ b/apps/web/src/app/sign-up/[[...sign-up]]/SignUpForm.tsx
@@ -298,6 +298,7 @@ export default function SignUpForm() {
           font-family: var(--font-mono);
           font-size: 0.875rem;
           transition: border-color var(--transition);
+          caret-color: var(--primary);
         }
 
         .auth-input:focus {

--- a/apps/web/src/app/waitlist/page.tsx
+++ b/apps/web/src/app/waitlist/page.tsx
@@ -81,12 +81,26 @@ export default function WaitlistPage() {
           display: none !important;
         }
 
+        .cl-formFieldLabel {
+          color: var(--foreground) !important;
+          font-family: var(--font-mono) !important;
+          font-size: 0.75rem !important;
+          font-weight: 500 !important;
+          text-transform: uppercase !important;
+          letter-spacing: 0.05em !important;
+        }
+
         .cl-formFieldInput {
           background: var(--background) !important;
           border: 1px solid var(--border) !important;
           border-radius: 0 !important;
           color: var(--foreground) !important;
           font-family: var(--font-mono) !important;
+        }
+
+        .cl-formFieldInput::placeholder {
+          color: var(--muted) !important;
+          opacity: 0.7 !important;
         }
 
         .cl-formFieldInput:focus {

--- a/apps/web/src/app/waitlist/page.tsx
+++ b/apps/web/src/app/waitlist/page.tsx
@@ -96,6 +96,7 @@ export default function WaitlistPage() {
           border-radius: 0 !important;
           color: var(--foreground) !important;
           font-family: var(--font-mono) !important;
+          caret-color: var(--primary) !important;
         }
 
         .cl-formFieldInput::placeholder {


### PR DESCRIPTION
Add brand-consistent orange blinking cursor to all auth form input fields (sign-in, sign-up, waitlist).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns auth form input visuals with brand styling.
> 
> - Set `caret-color: var(--primary)` on `auth-input` for sign-in and sign-up
> - On waitlist, style `cl-formFieldLabel` (mono, uppercase, sizing) and update `cl-formFieldInput` with `caret-color: var(--primary)` and muted placeholder color/opacity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3adb10a589c5bc0152e4c18b2415dffdc9707711. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->